### PR TITLE
Add support for releasing windows wheels.

### DIFF
--- a/.github/workflows/buildReleaseAndPublishWindows.yml
+++ b/.github/workflows/buildReleaseAndPublishWindows.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
     # Don't run this in everyone's forks.
-    if: github.repository == 'llvm/torch-mlir-release'
+    if: github.repository == 'sahas3/torch-mlir-release'
     strategy:
       matrix:
         package: [torch-mlir]

--- a/.github/workflows/buildReleaseAndPublishWindows.yml
+++ b/.github/workflows/buildReleaseAndPublishWindows.yml
@@ -1,0 +1,80 @@
+name: Build Release and Publish windows wheels
+
+on:
+  workflow_dispatch:
+  schedule:
+  # Runs at 11:00 AM UTC, which is 3:00 AM PST (UTC-8)
+   - cron: '0 11 * * *'
+
+# Ensure that only a single job or workflow using the same
+# concurrency group will run at a time. This would cancel
+# any in-progress jobs in the same github workflow and github
+# ref (e.g. refs/heads/main or refs/pull/<pr_number>/merge).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_x64_msvc:
+    name: windows x86_64 msvc Build
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: bash
+    # Elevates permissions for `GITHUB_TOKEN`'s content scope (to allow this action to make a release)
+    permissions:
+      contents: write
+    # Don't run this in everyone's forks.
+    if: github.repository == 'llvm/torch-mlir-release'
+    strategy:
+      matrix:
+        package: [torch-mlir]
+        py_version: [cp310-cp310, cp311-cp311]
+
+    steps:
+      - name: Checkout torch-mlir
+        uses: actions/checkout@v4
+        with:
+          repository: llvm/torch-mlir
+          ref: refs/heads/main
+          submodules: 'true'
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-build
+
+      - name: "Configuring MSVC"
+        uses: ilammy/msvc-dev-cmd@v1.13.0
+
+      - name: Build torch-mlir
+        run: |
+          cd $GITHUB_WORKSPACE
+          ./build_tools/python_deploy/build_windows_ci.sh
+
+      - name: Build Python wheels and smoke test
+        run: |
+          tm_package_version="$(printf '%(%Y%m%d)T.${{ github.run_number }}')"
+          echo "tm_package_version=${tm_package_version}" >> $GITHUB_ENV
+          printf "TORCH_MLIR_PYTHON_PACKAGE_VERSION=%s\n" ${tm_package_version} > ./torch_mlir_package_version
+          pip install delvewheel
+          TORCH_MLIR_PYTHON_PACKAGE_VERSION=${tm_package_version} TORCH_MLIR_CMAKE_BUILD_DIR="build" TORCH_MLIR_CMAKE_ALREADY_BUILT=1 python setup.py bdist_wheel
+          delvewheel repair --add-path ./build/tools/torch-mlir/python_packages/torch_mlir/torch_mlir/_mlir_libs --add-dll TorchMLIRAggregateCAPI.dll --no-dll 'c10.dll;torch_python.dll;torch_cpu.dll' -v dist/torch_mlir*.whl -w dist
+
+      - name: Upload python wheels
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: snapshot-${{ matrix.package }}-${{ matrix.py_version }}-${{ env.tm_package_version }}
+          path: dist
+
+      - name: Release python wheels
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          artifacts: dist/*.whl
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "dev-wheels"
+          name: "dev-wheels"
+          body: "Automatic snapshot release of torch-mlir python wheels."
+          removeArtifacts: false
+          allowUpdates: true
+          replacesArtifacts: true
+          makeLatest: true

--- a/.github/workflows/buildReleaseAndPublishWindows.yml
+++ b/.github/workflows/buildReleaseAndPublishWindows.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
     # Don't run this in everyone's forks.
-    if: github.repository == 'sahas3/torch-mlir-release'
+    if: github.repository == 'llvm/torch-mlir-release'
     strategy:
       matrix:
         package: [torch-mlir]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository houses release automation for torch-mlir. It is isolated from the main repository
 so that we can more strictly control people with write access.
 
-### Python Releases (x86 linux)
+### Python Releases (x86 linux and windows)
 Python wheels for torch-mlir are auto-generated every night and made available at [this release page](https://github.com/llvm/torch-mlir-release/releases/tag/dev-wheels).
 
 To install via `pip`, run:
@@ -18,4 +18,4 @@ or add this to `requirements.txt`:
 torch-mlir
 ```
 
-At the moment only linux-x86_64 builds are published, but this may be updated if the need arises (and we find appropriate owners to maintain the automation).
+At the moment only linux and windows x86_64 builds are published, but this may be updated if the need arises (and we find appropriate owners to maintain the automation).


### PR DESCRIPTION
This PR adds support for windows nightly build for releasing `torch-mlir` python wheels following the work done for linux. 
Here's the job for the windows build: https://github.com/sahas3/torch-mlir-release/actions/runs/11425775316