### PR TITLE
Build Windows releases for Python 3.12

### DIFF
--- a/.github/workflows/buildReleaseAndPublishWindows.yml
+++ b/.github/workflows/buildReleaseAndPublishWindows.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         package: [torch-mlir]
-        py_version: [cp310-cp310, cp311-cp311]
+        py_version: [cp310-cp310, cp311-cp311, cp312-312]
 
     steps:
       - name: Checkout torch-mlir


### PR DESCRIPTION
Pre-built installers are not available for Python 3.11. The latest 3.11 release 3.11.11, but Windows installers for 3.11 are only available up to version 3.11.9 (see https://www.python.org/downloads/windows/). Therefore, offering wheels for Python 3.12 seems reasonable.