### PR TITLE
Limit building wheels for Windows to Python 3.11

### DIFF
--- a/.github/workflows/buildReleaseAndPublishWindows.yml
+++ b/.github/workflows/buildReleaseAndPublishWindows.yml
@@ -29,7 +29,9 @@ jobs:
     strategy:
       matrix:
         package: [torch-mlir]
-        py_version: [cp310-cp310, cp311-cp311, cp312-312]
+        # TODO(#10): `py_version` has no effect and wheels only get build for 3.11.
+        # py_version: [cp310-cp310, cp311-cp311, cp312-cp312]
+        py_version: [cp311-cp311]
 
     steps:
       - name: Checkout torch-mlir


### PR DESCRIPTION
All other build default to Python 3.11 with the only difference that the artifact name includes a Python version but the artifact itself does not contain a build for that version, see #10.